### PR TITLE
update README, simplify Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,7 @@
-
-# Library locations
-MPI_LOC = /opt/openmpi
-FFTW_LOC = /opt/fftw-3.3.4
+# GNU Makefile
 
 # The compiler
-CXX = $(MPI_LOC)/bin/mpic++
+CXX = mpic++
 
 # Compiler parameters
 # -Wall		shows all warnings when compiling
@@ -13,7 +10,7 @@ CXX = $(MPI_LOC)/bin/mpic++
 CXXFLAGS = -Wall -std=c++11 -O3
 
 # Linker parameters
-LFLAGS = -L$(FFTW_LOC)/lib -lfftw3_mpi -lfftw3 -lm -L$(MPI_LOC)/lib -lmpi
+LFLAGS = -lfftw3_mpi -lfftw3 -lm -lmpi
 
 # Paths
 BIN_PATH = bin
@@ -24,7 +21,7 @@ OUTPUT_PATH = output
 APP = $(BIN_PATH)/pfc
 
 # Application compilation settings
-APP_CXXFLAGS = $(CXXFLAGS) -Iinclude -I$(FFTW_LOC)/include -I$(MPI_LOC)/include
+APP_CXXFLAGS = $(CXXFLAGS) -Iinclude
 
 # Object files
 OBJS = obj/main.o obj/pfc.o obj/mechanical_equilibrium.o
@@ -63,4 +60,3 @@ clean:
 	rm -rf $(BIN_PATH)
 	rm -rf $(OUTPUT_PATH)
 	rm -rf docs/html
-

--- a/README.md
+++ b/README.md
@@ -3,17 +3,68 @@
 
 ## Overview
 
-The phase-field crystal (PFC) models liquid-solid phase transformations of crystals and can describe elasticity, plasticity and topological defects.
+The phase-field crystal (PFC) models liquid-solid phase transformations of
+crystals and can describe elasticity, plasticity and topological defects.
 
-The program is a finite-difference based implementation of the PFC model. It also enables to perform elastic equilibration during the PFC time evolution. The L-BFGS algorithm is implemented to perform the elastic equilibration.
-
-For more details, see the project report: http://kodu.ut.ee/~kreimre/phase_field_crystal_report.pdf
+The program is a finite-difference based implementation of the PFC model. It
+also enables to perform elastic equilibration during the PFC time evolution. The
+L-BFGS algorithm is implemented to perform the elastic equilibration.
 
 ## Example results
 
-The following videos show time evolution of the PFC model for two systems. First is a circular grain in a monocrystal. The second system consists of three different orientation seeds in a supercooled liquid and results in a crystal consisting of three grains.
+The following videos show time evolution of the PFC model for two systems. First
+is a circular grain in a monocrystal. The second system consists of three
+different orientation seeds in a supercooled liquid and results in a crystal
+consisting of three grains.
 
-![grain-contraction](https://github.com/eimrek/phase-field-crystal-mpi/blob/master/misc/img/grain_contraction.gif) ![seed-growth](https://github.com/eimrek/phase-field-crystal-mpi/blob/master/misc/img/seed_growth.gif)
+![grain-contraction][gc] ![seed-growth][sg]
 
+## Usage
 
+### Python
 
+Python code is in the `python_code` directory. It requires a sub-directory named
+"fig": create it before executing. Then, simply run
+
+``` bash
+$ python main.py
+```
+
+This will write an image, `fig/phi.png`, for your viewing pleasure.
+
+### C++
+
+You must compile the C++ code. To do so, run `make` from the top-level
+directory. This will create the executable, `src/pfc`.
+
+`pfc` requires a sub-directory named "output": create it before executing.
+The default behavior is to write three files:
+
+1. `initial_conf.bin`, representing the initial condition.
+2. `eta50.bin`, representing the system after 400 timesteps.
+3. `eta100.bin`, representing the system after 800 timesteps.
+
+Each file contains the list of complex numbers, represented in 8-byte
+double-precision, and written out in octal form. The fastest moving index is
+*y*=[0,512], then *x*=[0,512], and finally *c*=[0,2]. To convert from octal to
+ASCII, use the octal dump utility:
+
+```bash
+$ od -v -t fD file.bin
+```
+
+Perhaps a more useful method is to use the `misc/plot_binary_data.py` script.
+Supply a `.bin` data file, and it will convert it to a `.png`:
+
+``` bash
+$ python misc/plot_binary_data.py output/initial_conf.bin
+Creating output/initial_conf.png from output/initial_conf.bin
+```
+
+Note that if you change the grid size in the C++ source, you will have to change
+the dimensions in `plot_binary_data.py` as well.
+
+<!--References-->
+
+[gc]: misc/img/grain_contraction.gif
+[sg]: misc/img/seed_growth.gif

--- a/misc/plot_binary_data.py
+++ b/misc/plot_binary_data.py
@@ -1,0 +1,33 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import sys
+
+if len(sys.argv) != 2:
+    print("Please supply a filename to convert.")
+    exit
+
+def print_comp(eta_):
+    for i in range(nx):
+        print("|", end="")
+        for j in range(ny):
+            print("%11.4e"%eta_[i, j], end="")
+        print("|")
+
+filepath = sys.argv[1]
+imagename = filepath.replace("bin", "png")
+
+print("Creating {0} from {1}".format(imagename, filepath))
+
+nx = 512
+ny = 512
+nc = 3
+flat = np.fromfile(filepath, dtype=np.complex128, count=-1, sep="")
+eta = flat.reshape(nc, nx, ny)
+
+val = np.abs(eta[0]) + np.abs(eta[1]) + np.abs(eta[2])
+plt.pcolormesh(val)
+plt.xlabel(r"$x$")
+plt.ylabel(r"$y$")
+plt.xlim([0, nx])
+plt.ylim([0, ny])
+plt.savefig(imagename, dpi=400, bbox_inches="tight")


### PR DESCRIPTION
The proposed changes improve documentation and generalize the build process.

- Removed specialized library locations from `Makefile`: if things are installed in standard locations, the FFTW and MPI include flags are not necessary.
- Copied (with minor revisions) `read_binary_eta.ipynb` into `plot_binary_data.py` to simplify execution and editing.
- Documented usage of C++, Python, and utilities in `README.md`.
- Removed broken link to project report.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eimrek/phase-field-crystal-mpi/3)
<!-- Reviewable:end -->
